### PR TITLE
Fix - FindApiResourcesByScopeAsync() searching wrong members

### DIFF
--- a/IdentityServer4-Samples/IdentityServer4-mongo/IdentityServer4-mongo/Quickstart/Store/CustomResourceStore.cs
+++ b/IdentityServer4-Samples/IdentityServer4-mongo/IdentityServer4-mongo/Quickstart/Store/CustomResourceStore.cs
@@ -41,7 +41,7 @@ namespace QuickstartIdentityServer.Quickstart.Store
         {
             return Task.Run(() =>
             {
-                var list = _dbRepository.Where<ApiResource>(a => scopeNames.Contains(a.Name));
+                var list = _dbRepository.Where<ApiResource>(a => a.Scopes.Any(s => scopeNames.Contains(s.Name)));
 
                 var t = list.ToList();
                 return list.AsEnumerable();


### PR DESCRIPTION
FindApiResourcesByScopeAsync() should search ApiResources by their scopes - not by the names of the ApiResources.

Used IdentityServer4.EntityFramework as the implementation resource:
https://github.com/IdentityServer/IdentityServer4.EntityFramework/blob/73c87eeebd1fc0b5984e58c824dd5bc4def70ad9/src/IdentityServer4.EntityFramework/Stores/ResourceStore.cs#L76