### PR TITLE
Use  Task.Result and not Task.Run to return task result 

### DIFF
--- a/IdentityServer4-Samples/IdentityServer4-mongo-AspIdentity/QuickstartIdentityServer/Quickstart/Store/CustomClientStore.cs
+++ b/IdentityServer4-Samples/IdentityServer4-mongo-AspIdentity/QuickstartIdentityServer/Quickstart/Store/CustomClientStore.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using IdentityServer4.Models;
-using MongoDB.Driver;
 using QuickstartIdentityServer.Quickstart.Interface;
 
 namespace QuickstartIdentityServer.Quickstart.Store
@@ -19,11 +15,9 @@ namespace QuickstartIdentityServer.Quickstart.Store
 
         public Task<Client> FindClientByIdAsync(string clientId)
         {
-            return Task.Run(() =>
-            {
-                var client = _dbRepository.Single<Client>(c => c.ClientId == clientId);
-                return client;
-            });
+            var client = _dbRepository.Single<Client>(c => c.ClientId == clientId);
+
+            return Task.FromResult(client);
         }
     }
 }

--- a/IdentityServer4-Samples/IdentityServer4-mongo-AspIdentity/QuickstartIdentityServer/Quickstart/Store/CustomPersistedGrantStore.cs
+++ b/IdentityServer4-Samples/IdentityServer4-mongo-AspIdentity/QuickstartIdentityServer/Quickstart/Store/CustomPersistedGrantStore.cs
@@ -1,5 +1,4 @@
 ﻿using IdentityServer4.Stores;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -22,63 +21,38 @@ namespace QuickstartIdentityServer.Quickstart.Store
 
         public Task<IEnumerable<PersistedGrant>> GetAllAsync(string subjectId)
         {
-            return Task.Run(() =>
-            {
-                var result = _dbRepository.Where<PersistedGrant>(i => i.SubjectId == subjectId);
-                return result.AsEnumerable();
-            });
-
+            var result = _dbRepository.Where<PersistedGrant>(i => i.SubjectId == subjectId);
+            return Task.FromResult(result.AsEnumerable());
         }
 
         public Task<PersistedGrant> GetAsync(string key)
         {
-            return Task.Run(() =>
-            {
-                var result = _dbRepository.Single<PersistedGrant>(i => i.Key == key);
-                return result;
-            });
-
+            var result = _dbRepository.Single<PersistedGrant>(i => i.Key == key);
+            return Task.FromResult(result);
         }
 
         public Task RemoveAllAsync(string subjectId, string clientId)
         {
-            return Task.Run(() =>
-            {
-                _dbRepository.Delete<PersistedGrant>(i => i.SubjectId == subjectId && i.ClientId == clientId);
-
-                return;
-            });
+            _dbRepository.Delete<PersistedGrant>(i => i.SubjectId == subjectId && i.ClientId == clientId);
+            return Task.FromResult(0);
         }
 
         public Task RemoveAllAsync(string subjectId, string clientId, string type)
         {
-
-            return Task.Run(() =>
-            {
-                _dbRepository.Delete<PersistedGrant>(i => i.SubjectId == subjectId && i.ClientId == clientId && i.Type == type);
-
-                return;
-            });
+            _dbRepository.Delete<PersistedGrant>(i => i.SubjectId == subjectId && i.ClientId == clientId && i.Type == type);
+            return Task.FromResult(0);
         }
 
         public Task RemoveAsync(string key)
         {
-            return Task.Run(() =>
-            {
-                _dbRepository.Delete<PersistedGrant>(i => i.Key == key);
-
-                return;
-            });
+            _dbRepository.Delete<PersistedGrant>(i => i.Key == key);
+            return Task.FromResult(0);
         }
 
         public Task StoreAsync(PersistedGrant grant)
         {
-            return Task.Run(() =>
-            {
-                _dbRepository.Add<PersistedGrant>(grant);
-
-                return;
-            });
+            _dbRepository.Add<PersistedGrant>(grant);
+            return Task.FromResult(0);
         }
     }
 }

--- a/IdentityServer4-Samples/IdentityServer4-mongo-AspIdentity/QuickstartIdentityServer/Quickstart/Store/CustomResourceStore.cs
+++ b/IdentityServer4-Samples/IdentityServer4-mongo-AspIdentity/QuickstartIdentityServer/Quickstart/Store/CustomResourceStore.cs
@@ -17,7 +17,6 @@ namespace QuickstartIdentityServer.Quickstart.Store
             _dbRepository = repository;
         }
 
-
         private IEnumerable<ApiResource> GetAllApiResources()
         {
             return _dbRepository.All<ApiResource>();
@@ -31,46 +30,27 @@ namespace QuickstartIdentityServer.Quickstart.Store
         public Task<ApiResource> FindApiResourceAsync(string name)
         {
             if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name));
-            return Task.Run(() =>
-            {
-                return _dbRepository.Single<ApiResource>(a => a.Name == name);
-            });
+
+            return Task.FromResult(_dbRepository.Single<ApiResource>(a => a.Name == name));
         }
 
         public Task<IEnumerable<ApiResource>> FindApiResourcesByScopeAsync(IEnumerable<string> scopeNames)
         {
-            return Task.Run(() =>
-            {
-                var list = _dbRepository.Where<ApiResource>(a => scopeNames.Contains(a.Name));
+            var list = _dbRepository.Where<ApiResource>(a => scopeNames.Contains(a.Name));
 
-                var t = list.ToList();
-                return list.AsEnumerable();
-            });
-
-
+            return Task.FromResult(list.AsEnumerable());
         }
 
         public Task<IEnumerable<IdentityResource>> FindIdentityResourcesByScopeAsync(IEnumerable<string> scopeNames)
         {
-            return Task.Run(() =>
-            {
-                var list = _dbRepository.Where<IdentityResource>(e => scopeNames.Contains(e.Name));
-                return list.AsEnumerable();
-            });
+            var list = _dbRepository.Where<IdentityResource>(e => scopeNames.Contains(e.Name));
+            return Task.FromResult(list.AsEnumerable());
         }
 
         public Task<Resources> GetAllResources()
         {
-            return Task.Run(() =>
-            {
-                var result = new Resources(GetAllIdentityResources(), GetAllApiResources());
-                return result;
-            });
-        }
-
-        private Func<IdentityResource, bool> BuildPredicate(Func<IdentityResource, bool> predicate)
-        {
-            return predicate;
+            var result = new Resources(GetAllIdentityResources(), GetAllApiResources());
+            return Task.FromResult(result);
         }
     }
 }

--- a/IdentityServer4-Samples/IdentityServer4-mongo/IdentityServer4-mongo/Quickstart/Store/CustomClientStore.cs
+++ b/IdentityServer4-Samples/IdentityServer4-mongo/IdentityServer4-mongo/Quickstart/Store/CustomClientStore.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using IdentityServer4.Models;
-using MongoDB.Driver;
 using QuickstartIdentityServer.Quickstart.Interface;
 
 namespace QuickstartIdentityServer.Quickstart.Store
@@ -19,11 +15,9 @@ namespace QuickstartIdentityServer.Quickstart.Store
 
         public Task<Client> FindClientByIdAsync(string clientId)
         {
-            return Task.Run(() =>
-            {
-                var client = _dbRepository.Single<Client>(c => c.ClientId == clientId);
-                return client;
-            });
+            var client = _dbRepository.Single<Client>(c => c.ClientId == clientId);
+
+            return Task.FromResult(client);
         }
     }
 }

--- a/IdentityServer4-Samples/IdentityServer4-mongo/IdentityServer4-mongo/Quickstart/Store/CustomPersistedGrantStore.cs
+++ b/IdentityServer4-Samples/IdentityServer4-mongo/IdentityServer4-mongo/Quickstart/Store/CustomPersistedGrantStore.cs
@@ -1,9 +1,8 @@
-﻿using IdentityServer4.Stores;
-using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using IdentityServer4.Models;
+using IdentityServer4.Stores;
 using QuickstartIdentityServer.Quickstart.Interface;
 
 namespace QuickstartIdentityServer.Quickstart.Store
@@ -22,63 +21,38 @@ namespace QuickstartIdentityServer.Quickstart.Store
 
         public Task<IEnumerable<PersistedGrant>> GetAllAsync(string subjectId)
         {
-            return Task.Run(() =>
-            {
-                var result = _dbRepository.Where<PersistedGrant>(i => i.SubjectId == subjectId);
-                return result.AsEnumerable();
-            });
-
+            var result = _dbRepository.Where<PersistedGrant>(i => i.SubjectId == subjectId);
+            return Task.FromResult(result.AsEnumerable());
         }
 
         public Task<PersistedGrant> GetAsync(string key)
         {
-            return Task.Run(() =>
-            {
-                var result = _dbRepository.Single<PersistedGrant>(i => i.Key == key);
-                return result;
-            });
-
+            var result = _dbRepository.Single<PersistedGrant>(i => i.Key == key);
+            return Task.FromResult(result);
         }
 
         public Task RemoveAllAsync(string subjectId, string clientId)
         {
-            return Task.Run(() =>
-            {
-                _dbRepository.Delete<PersistedGrant>(i => i.SubjectId == subjectId && i.ClientId == clientId);
-
-                return;
-            });
+            _dbRepository.Delete<PersistedGrant>(i => i.SubjectId == subjectId && i.ClientId == clientId);
+            return Task.FromResult(0);
         }
 
         public Task RemoveAllAsync(string subjectId, string clientId, string type)
         {
-
-            return Task.Run(() =>
-            {
-                _dbRepository.Delete<PersistedGrant>(i => i.SubjectId == subjectId && i.ClientId == clientId && i.Type == type);
-
-                return;
-            });
+            _dbRepository.Delete<PersistedGrant>(i => i.SubjectId == subjectId && i.ClientId == clientId && i.Type == type);
+            return Task.FromResult(0);
         }
 
         public Task RemoveAsync(string key)
         {
-            return Task.Run(() =>
-            {
-                _dbRepository.Delete<PersistedGrant>(i => i.Key == key);
-
-                return;
-            });
+            _dbRepository.Delete<PersistedGrant>(i => i.Key == key);
+            return Task.FromResult(0);
         }
 
         public Task StoreAsync(PersistedGrant grant)
         {
-            return Task.Run(() =>
-            {
-                _dbRepository.Add<PersistedGrant>(grant);
-
-                return;
-            });
+            _dbRepository.Add<PersistedGrant>(grant);
+            return Task.FromResult(0);
         }
     }
 }

--- a/IdentityServer4-Samples/IdentityServer4-mongo/IdentityServer4-mongo/Quickstart/Store/CustomResourceStore.cs
+++ b/IdentityServer4-Samples/IdentityServer4-mongo/IdentityServer4-mongo/Quickstart/Store/CustomResourceStore.cs
@@ -17,7 +17,6 @@ namespace QuickstartIdentityServer.Quickstart.Store
             _dbRepository = repository;
         }
 
-
         private IEnumerable<ApiResource> GetAllApiResources()
         {
             return _dbRepository.All<ApiResource>();
@@ -31,41 +30,28 @@ namespace QuickstartIdentityServer.Quickstart.Store
         public Task<ApiResource> FindApiResourceAsync(string name)
         {
             if (string.IsNullOrEmpty(name)) throw new ArgumentNullException(nameof(name));
-            return Task.Run(() =>
-            {
-                return _dbRepository.Single<ApiResource>(a => a.Name == name);
-            });
+
+            return Task.FromResult(_dbRepository.Single<ApiResource>(a => a.Name == name));
         }
 
         public Task<IEnumerable<ApiResource>> FindApiResourcesByScopeAsync(IEnumerable<string> scopeNames)
         {
-            return Task.Run(() =>
-            {
-                var list = _dbRepository.Where<ApiResource>(a => scopeNames.Contains(a.Name));
+            var list = _dbRepository.Where<ApiResource>(a => scopeNames.Contains(a.Name));
 
-                var t = list.ToList();
-                return list.AsEnumerable();
-            });
-
-
+            return Task.FromResult(list.AsEnumerable());
         }
 
         public Task<IEnumerable<IdentityResource>> FindIdentityResourcesByScopeAsync(IEnumerable<string> scopeNames)
         {
-            return Task.Run(() =>
-            {
-                var list = _dbRepository.Where<IdentityResource>(e => scopeNames.Contains(e.Name));
-                return list.AsEnumerable();
-            });
+            var list = _dbRepository.Where<IdentityResource>(e => scopeNames.Contains(e.Name));
+
+            return Task.FromResult(list.AsEnumerable());
         }
 
         public Task<Resources> GetAllResources()
         {
-            return Task.Run(() =>
-            {
-                var result = new Resources(GetAllIdentityResources(), GetAllApiResources());
-                return result;
-            });
+            var result = new Resources(GetAllIdentityResources(), GetAllApiResources());
+            return Task.FromResult(result);
         }
 
         private Func<IdentityResource, bool> BuildPredicate(Func<IdentityResource, bool> predicate)


### PR DESCRIPTION
Task.Run queues up another thread for processing. Being that we aren't actually doing any async processing with the MongoRepository, this is not needed. We can simply use Task.FromResult to satisfy the return type of the method without queuing up additional thread for processing the result.

See MSDN:
https://msdn.microsoft.com/en-us/library/hh195051(v=vs.110).aspx